### PR TITLE
Feature vectors as column vectors

### DIFF
--- a/lab_11.cpp
+++ b/lab_11.cpp
@@ -204,7 +204,7 @@ cv::Rect getSamplingRectangle(const cv::Size& img_size)
 cv::Mat extractTrainingSamples(const cv::Mat& source_image, const cv::Rect& sampling_rectangle)
 {
   cv::Mat patch = source_image(sampling_rectangle).clone();
-  cv::Mat samples = patch.reshape(1, patch.total());
+  cv::Mat samples = patch.reshape(1, patch.total()).t();
   return samples;
 }
 

--- a/lab_11.cpp
+++ b/lab_11.cpp
@@ -7,10 +7,10 @@
 // ------ Declarations for utility functions ------
 
 /// \brief Replace a ratio of current_samples with new_samples
-/// \param[in] current_samples Samples used in the current model.
+/// \param[in] old_samples Samples used in the current model.
 /// \param[in] new_samples New samples.
 /// \param[in] update_ratio The ratio of samples to replace on average.
-void updateSamples(cv::Mat& current_samples, const cv::Mat& new_samples, float update_ratio);
+void updateSamples(cv::Mat& old_samples, const cv::Mat& new_samples, float update_ratio);
 
 /// \brief Returns a binary image (values 0 or 255) which is the result of segmenting the input.
 /// \param[in] input_image Assumed to be of type CV_8U.
@@ -143,7 +143,7 @@ void lab11()
 }
 
 
-void updateSamples(cv::Mat& current_samples, const cv::Mat& new_samples, float update_ratio)
+void updateSamples(cv::Mat& old_samples, const cv::Mat& new_samples, float update_ratio)
 {
   // Draw uniformly distributed random numbers
   cv::Mat rand_num = cv::Mat::zeros(1,new_samples.cols,CV_32FC1);
@@ -154,7 +154,7 @@ void updateSamples(cv::Mat& current_samples, const cv::Mat& new_samples, float u
   {
     if (rand_num.at<float>(0,i) < update_ratio)
     {
-      new_samples.col(i).copyTo(current_samples.col(i));
+      new_samples.col(i).copyTo(old_samples.col(i));
     }
   }
 }

--- a/lab_11.cpp
+++ b/lab_11.cpp
@@ -6,11 +6,11 @@
 
 // ------ Declarations for utility functions ------
 
-/// \brief Replace a ratio of old_samples with new_samples
-/// \param[in] old_samples Samples used in the current model.
+/// \brief Replace a ratio of current_samples with new_samples
+/// \param[in] current_samples Samples used in the current model.
 /// \param[in] new_samples New samples.
 /// \param[in] update_ratio The ratio of samples to replace on average.
-void updateSamples(cv::Mat& old_samples, const cv::Mat& new_samples, float update_ratio);
+void updateSamples(cv::Mat& current_samples, const cv::Mat& new_samples, float update_ratio);
 
 /// \brief Returns a binary image (values 0 or 255) which is the result of segmenting the input.
 /// \param[in] input_image Assumed to be of type CV_8U.
@@ -143,7 +143,7 @@ void lab11()
 }
 
 
-void updateSamples(cv::Mat& old_samples, const cv::Mat& new_samples, float update_ratio)
+void updateSamples(cv::Mat& current_samples, const cv::Mat& new_samples, float update_ratio)
 {
   // Draw uniformly distributed random numbers
   cv::Mat rand_num = cv::Mat::zeros(1,new_samples.cols,CV_32FC1);
@@ -154,7 +154,7 @@ void updateSamples(cv::Mat& old_samples, const cv::Mat& new_samples, float updat
   {
     if (rand_num.at<float>(0,i) < update_ratio)
     {
-      new_samples.col(i).copyTo(old_samples.col(i));
+      new_samples.col(i).copyTo(current_samples.col(i));
     }
   }
 }

--- a/multivariate_normal_model.cpp
+++ b/multivariate_normal_model.cpp
@@ -10,7 +10,7 @@ MultivariateNormalModel::MultivariateNormalModel(const cv::Mat& samples)
 
 void MultivariateNormalModel::performTraining(const cv::Mat& samples)
 {
-  cv::calcCovarMatrix(samples, covariance_, mean_, cv::COVAR_NORMAL | cv::COVAR_ROWS);
+  cv::calcCovarMatrix(samples, covariance_, mean_, cv::COVAR_NORMAL | cv::COVAR_COLS);
   cv::invert(covariance_, inverse_covariance_, cv::DECOMP_SVD);
 }
 
@@ -21,10 +21,10 @@ cv::Mat MultivariateNormalModel::computeMahalanobisDistances(const cv::Mat& imag
   // We get a pretty good representation by multiplying the distances with 1000.
   constexpr double dist_to_uint8_scale = 1000.0;
 
-  // Convert to double precision and reshape to feature vector rows.
+  // Convert to double precision and reshape to feature vector columns.
   cv::Mat samples_in_double_precision;
   image.convertTo(samples_in_double_precision, CV_64F);
-  samples_in_double_precision = samples_in_double_precision.reshape(1, samples_in_double_precision.total());
+  samples_in_double_precision = samples_in_double_precision.reshape(1, samples_in_double_precision.total()).t();
 
   cv::Mat mahalanobis_img(image.size(), CV_64FC1);
 
@@ -32,9 +32,9 @@ cv::Mat MultivariateNormalModel::computeMahalanobisDistances(const cv::Mat& imag
   // see https://docs.opencv.org/4.0.1/db/da5/tutorial_how_to_scan_images.html
   const auto mahalanobis_img_ptr = mahalanobis_img.ptr<double>();
 
-  for (int i=0; i < samples_in_double_precision.rows; ++i)
+  for (int i=0; i < samples_in_double_precision.cols; ++i)
   {
-    const cv::Mat sample = samples_in_double_precision.row(i);
+    const cv::Mat sample = samples_in_double_precision.col(i);
     mahalanobis_img_ptr[i] = cv::Mahalanobis(sample , mean_, inverse_covariance_);
   }
 


### PR DESCRIPTION
Nå er feature vektorene kolonner igjen.

Ellers lurer jeg på om det kan være hensiktsmessig å flytte omformingen av sample pikslene til metoden extractFeatures. Denne kjøres på hvert bilde uansett og det den spytter ut blir ikke brukt til noe annet enn som input til extractTrainingSamples som spytter ut 2D matrisen som brukes både til å initialisere modellen og til å beregne Mahalanobis avstandene.

Noen synspunkter? Jeg kan iterere videre på denne branchen eller vi kan ta det i en ny.

closes(#5)